### PR TITLE
feat(asm): allow mail to receive advances suscription managment (asm)…

### DIFF
--- a/lib/send_grid_mailer/definition.rb
+++ b/lib/send_grid_mailer/definition.rb
@@ -8,6 +8,7 @@ module SendGridMailer
       :set_recipients,
       :set_subject,
       :set_content,
+      :set_unsubscribe_group,
       :add_attachment,
       :add_header,
       :add_category
@@ -27,6 +28,12 @@ module SendGridMailer
       return unless value
 
       mail.template_id = value
+    end
+
+    def set_unsubscribe_group(value, groups_to_display = [])
+      return unless value
+
+      mail.asm = SendGrid::ASM.new(group_id: value, groups_to_display: groups_to_display)
     end
 
     def set_sender(email)

--- a/lib/send_grid_mailer/logger.rb
+++ b/lib/send_grid_mailer/logger.rb
@@ -11,6 +11,7 @@ module SendGridMailer
         "To" => log_emails(personalization, :tos),
         "Cc" => log_emails(personalization, :ccs),
         "Bcc" => log_emails(personalization, :bccs),
+        "ASM" => log_pairs(mail.asm.as_json),
         "Substitutions" => log_pairs(personalization.substitutions),
         "Headers" => log_pairs(personalization.headers),
         "body" => log_contents(mail),

--- a/lib/send_grid_mailer/mailer_base_ext.rb
+++ b/lib/send_grid_mailer/mailer_base_ext.rb
@@ -33,6 +33,7 @@ module ActionMailer
       set_recipients(:to, params[:to])
       set_recipients(:cc, params[:cc])
       set_recipients(:bcc, params[:bcc])
+      set_unsubscribe_group(params[:asm][:group_id], params[:asm][:groups_to_display])
       set_subject(params[:subject]) unless sg_definition.subject?
       set_body(params)
       add_attachments


### PR DESCRIPTION
Qué se hizo?

Se agregó el asm params al email de Sendgrid. Esto permite poder activar los links de anulación de suscripción de los dynamics templates. 